### PR TITLE
Fix B-tree example typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ int main() {
     btree_ascend(tr, &(struct user){.first="",.last="Murphy"}, user_iter, NULL);
 
     printf("\n-- loop iterator (same as previous) --\n");
-    struct btree_iter *iter = btree_iter_new(btree);
+    struct btree_iter *iter = btree_iter_new(tr);
     bool ok = btree_iter_seek(iter, &(struct user){.first="",.last="Murphy"});
     while (ok) {
         const struct user *user = btree_iter_item(iter);


### PR DESCRIPTION
Fix a typo in the B-tree example in the README.md by changing the argument in the function btree_iter_new() from "btree" to "tr" to accurately reflect the intended usage.